### PR TITLE
update(react/react-dom): 0.0.0-experimental-e3ebcd54b-20240405

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "react19",
       "version": "0.0.0",
       "dependencies": {
-        "react": "^0.0.0-experimental-eb33bd747-20240312",
-        "react-dom": "^0.0.0-experimental-eb33bd747-20240312",
+        "react": "0.0.0-experimental-e3ebcd54b-20240405",
+        "react-dom": "0.0.0-experimental-e3ebcd54b-20240405",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
@@ -4053,22 +4053,22 @@
       ]
     },
     "node_modules/react": {
-      "version": "0.0.0-experimental-eb33bd747-20240312",
-      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-eb33bd747-20240312.tgz",
-      "integrity": "sha512-fTSjcXbuBBJRnTCvT6fHJ01eCeDCPRXW+fPTiL0f2KJ56l6q29Jl6YoB/0Lbif6l3T+4iJh1gGTZ+lFhQ/cycg==",
+      "version": "0.0.0-experimental-e3ebcd54b-20240405",
+      "resolved": "https://registry.npmjs.org/react/-/react-0.0.0-experimental-e3ebcd54b-20240405.tgz",
+      "integrity": "sha512-JlE1/jOLzhl0Nd+blmAeUno8t0io1hzawUuIWLNFRHgrxcUxyNkhlSwKhOfxtF73xylYNgJJHmXWGXdZB9tqxg==",
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "0.0.0-experimental-eb33bd747-20240312",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-eb33bd747-20240312.tgz",
-      "integrity": "sha512-Cleqh3TmqgWFo3yTl7h/mW1CmTeoTCGunRzwSUT+M4I1Dahid1KcuYybBjDypmTnivUMCO7UnudaptZhbw6x3w==",
+      "version": "0.0.0-experimental-e3ebcd54b-20240405",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.0.0-experimental-e3ebcd54b-20240405.tgz",
+      "integrity": "sha512-6d+Qy92j0IZv1CcOvIiPbhs+3BSEeztH39wSTJ0kurexlg+bhgfCw2+qLbo3djLzfo9KeMoojcCnaMqwRPOtoA==",
       "dependencies": {
-        "scheduler": "0.0.0-experimental-eb33bd747-20240312"
+        "scheduler": "0.0.0-experimental-e3ebcd54b-20240405"
       },
       "peerDependencies": {
-        "react": "0.0.0-experimental-eb33bd747-20240312"
+        "react": "0.0.0-experimental-e3ebcd54b-20240405"
       }
     },
     "node_modules/react-is": {
@@ -4318,9 +4318,9 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.0.0-experimental-eb33bd747-20240312",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-eb33bd747-20240312.tgz",
-      "integrity": "sha512-XAPn2WeniGzSK4XEr/Yl9cPfWUqwrRx9pTi3FM54PkwGbsjgiLB+KC2Nb15c7C9zN+eg255cMvb2UwNDdW9e8A=="
+      "version": "0.0.0-experimental-e3ebcd54b-20240405",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.0.0-experimental-e3ebcd54b-20240405.tgz",
+      "integrity": "sha512-VUTAH8poyVzJcxNB20aN+bTUk2tjgykf3Ie1vgdK6AZKcmK3IpFSyueZ5ZwIQlWj31dpEpBcAmKSLz7b69t63A=="
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^0.0.0-experimental-eb33bd747-20240312",
-    "react-dom": "^0.0.0-experimental-eb33bd747-20240312",
+    "react": "0.0.0-experimental-e3ebcd54b-20240405",
+    "react-dom": "0.0.0-experimental-e3ebcd54b-20240405",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Wasn't loading for me. I think the old tag was removed - so bumped to latest experimental according to `yarn info`, and it seems to work
```
    '0.0.0-experimental-e3ebcd54b-20240405': '2024-04-05T16:17:23.630Z'
  },
  ```
  